### PR TITLE
ci(tests): add codecov report

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -2,5 +2,6 @@ export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 }

--- a/.github/workflows/linters-tests-image.yaml
+++ b/.github/workflows/linters-tests-image.yaml
@@ -60,7 +60,7 @@ jobs:
           make generate manifests
           git diff --name-only
       - run: |
-          go test -cover -race -coverporfile=coverage.out ./...
+          go test -race -coverprofile=cover.out -covermode=atomic ./...
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/linters-tests-image.yaml
+++ b/.github/workflows/linters-tests-image.yaml
@@ -60,7 +60,12 @@ jobs:
           make generate manifests
           git diff --name-only
       - run: |
-          go test ./...
+          go test -cover -race -coverporfile=coverage.out ./...
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: registry-operator/registry-operator
 
   docker:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -race -covermode=atomic -coverprofile=coverage.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds Codecov report generation and uploading to the continuous integration process. Specifically, it incorporates Codecov to the CI pipeline, enabling the generation and uploading of coverage reports after running tests. The addition of this feature enhances code quality monitoring and facilitates better visibility into test coverage.

## Which issue(s) this PR resolves:
N/A

## Special notes for your reviewer:
Reviewers are encouraged to pay attention to the changes made to the CI workflow and ensure that the integration with Codecov is correctly implemented. Additionally, verification of test coverage reporting and any potential impact on existing CI processes is crucial.

## Additional documentation e.g., enhancement proposals, usage docs, etc.:
N/A
