### PR TITLE
chore(kustomize): remove 'next' suffix

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -21,3 +21,14 @@ jobs:
         with:
           requireScope: true
           subjectPattern: ^(?![A-Z]).+$
+          scopes: |
+            deps
+            operator
+            registry
+            cache
+            example
+            kustomize
+            e2e
+            integration
+            unit
+            gh-actions

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -14,7 +14,7 @@ metadata:
   namespace: system
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:

--- a/config/network-policy/allow-metrics-traffic.yaml
+++ b/config/network-policy/allow-metrics-traffic.yaml
@@ -5,7 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: allow-metrics-traffic
   namespace: system

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ kind: ServiceMonitor
 metadata:
   labels:
     control-plane: controller-manager
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/config/rbac/registry_editor_role.yaml
+++ b/config/rbac/registry_editor_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: registry-editor-role
 rules:

--- a/config/rbac/registry_viewer_role.yaml
+++ b/config/rbac/registry_viewer_role.yaml
@@ -3,7 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: registry-viewer-role
 rules:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/config/samples/v1alpha1_registry.yaml
+++ b/config/samples/v1alpha1_registry.yaml
@@ -2,7 +2,7 @@ apiVersion: registry-operator.dev/v1alpha1
 kind: Registry
 metadata:
   labels:
-    app.kubernetes.io/name: registry-operator-next
+    app.kubernetes.io/name: registry-operator
     app.kubernetes.io/managed-by: kustomize
   name: registry-sample
 spec: {}


### PR DESCRIPTION
- [ ] Changes covered by unit and/or e2e tests;
- [ ] Documentation and examples updated;

## What this PR does / why we need it:
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
Removed `next` suffix from kustomize configs.

## Which issue(s) this PR resolves:
<!--
Usage: `Resolves #<issue number>`, or `Resolves <link to the issue>`.
If PR is about `failing-tests`, please post the related tests in a comment and do not use `Resolves`
-->
N/A
