### PR TITLE
chore(tools): cleanup old versions on release

### DIFF
--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -27,8 +27,11 @@ jobs:
             registry
             cache
             example
+            image
             kustomize
             e2e
             integration
             unit
             gh-actions
+            build-system
+            tools


### PR DESCRIPTION
- [ ] Changes covered by unit and/or e2e tests;
- [ ] Documentation and examples updated;

## What this PR does / why we need it:
<!--
What code changes are made?
What problem does this PR addresses, or what feature this PR adds?
-->
Adds wrapper around `mike delete` to cleanup old/unsupported versions from documentation.

## Which issue(s) this PR resolves:
<!--
Usage: `Resolves #<issue number>`, or `Resolves <link to the issue>`.
If PR is about `failing-tests`, please post the related tests in a comment and do not use `Resolves`
-->
N/A
