### PR TITLE
ci(image): add org.opencontainers.image.description annotation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,6 +65,8 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.event.repository.owner.name }}/registry-operator:${{ github.ref_name }}
           build-args: VERSION=${{ github.ref_name }}
+          annotations: |
+            org.opencontainers.image.description
           labels: |
             org.opencontainers.image.title="registry-operator"
             org.opencontainers.image.authors="The Registry Operator Authors"


### PR DESCRIPTION
## Description

This PR adds the `org.opencontainers.image.description` annotation to the container image manifest in the release workflow, providing additional metadata about the image according to the OCI image specification.

## Changes
- Added `annotations` field in `.github/workflows/release.yaml`
- Includes `org.opencontainers.image.description` annotation

## Issue
Fixes #53

## Checklist
- [x] Changes follow the project's contribution guidelines
- [x] Documentation label applied (kind/documentation)
- [x] Ready for review